### PR TITLE
Fix model_testing_helpers.py's train/test halving

### DIFF
--- a/model_testing_helpers.py
+++ b/model_testing_helpers.py
@@ -79,7 +79,7 @@ def divyTrainAndTest( originalFileInput, trainFileOutput, testFileOutput ):
         curLine = 1
         
         openFile.seek(startEnd[0])
-        offset = 0
+        offset = startEnd[0]
         
         for line in openFile:
             if offset > startEnd[1]:


### PR DESCRIPTION
Set offset to startEnd[0] in model_testing_helpers.py's
divyTrainAndTest() function.

As trainLines contained line numbers for train sample of a user's
ListenerId (startEnd[0] being the start and startEnd[1] the end of the
listenerId's section), the number of sample rows for the train dataset
would always be correct as the for loop checked if the current line
belonged to the trainLines category. However, having relied on this
information and the offset as to where a new listenerId would begin, the
loop would start going over the original file from beginning of the file
to the place the listenerId would change. This caused a problem for test
file as all the other lines of the original would fill the test file
except for the specified trainLines mentioned. Replace offset from 0 to
startEnd[0] to solve this problem.